### PR TITLE
[ci skip] ***NO_CI*** [skip ci] Disable autotick bot for now

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -7,3 +7,6 @@ github:
   branch_name: main
   tooling_branch_name: main
 test: native_and_emulated
+bot:
+  version_updates:
+    skip: True


### PR DESCRIPTION
We were receiving PRs for Quarto pre-releases, and this is expected behavior of the bot for now.

A "skip" feature was generously added for us to quiet down those bot PRs.

See: https://github.com/regro/cf-scripts/issues/2642

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed) -- I think I don't need to do this because of ci skip, right?
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
